### PR TITLE
Convert sparse matrix to a dense one

### DIFF
--- a/src/preprocessing/grn_creation.py
+++ b/src/preprocessing/grn_creation.py
@@ -27,7 +27,7 @@ def create_GRN(cfg: ConfigParser) -> None:
     TFs = list(set(TFs).intersection(gene_names))
 
     # preparing GRNBoost2's input
-    real_cells_df = pd.DataFrame(real_cells.X, columns=real_cells.var_names)
+    real_cells_df = pd.DataFrame(real_cells.X.toarray(), columns=real_cells.var_names)
 
     # we can optionally pass a list of TFs to GRNBoost2
     print(f"Using {len(TFs)} TFs for GRN inference.")


### PR DESCRIPTION
I encountered a ValueError (shape mismatch) following the tutorial on running `python src/main.py --config configs/causal_gan.cfg --create_grn`. On investigating the error, it seems the data was read as sparse which pandas dataframe expects dense matrix. 

We can fix this in two ways: using `.todense()` or `.toarray()` depending on whether we want to return a `numpy.matrix` or `numpy.ndarray` object. Based on my research, seems the later is preferred as the use of `numpy.matrix` may be deprecated in the future. 

I tested this fix and I can successfully run the `--create_grn` function.