### PR TITLE
Fix training error during Causal GAN initialization

### DIFF
--- a/src/gans/gan.py
+++ b/src/gans/gan.py
@@ -1,5 +1,7 @@
 import os
 import typing
+import warnings
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -252,7 +254,10 @@ class GAN:
             Gene expression matrix of generated cells.
         """
         if checkpoint is not None:
-            self._load(checkpoint)
+            if not Path(checkpoint).exists():
+                warnings.warn(f"Checkpoint {checkpoint} does not exist.")
+            else:
+                self._load(checkpoint)
 
         # find how many batches to generate
         batch_no = int(np.ceil(cells_no / self.batch_size))
@@ -648,8 +653,11 @@ class GAN:
             self.crit_opt, crit_alpha_0, crit_alpha_final, max_steps
         )
 
-        if checkpoint is not None:
-            self._load(checkpoint, mode="training")
+        if checkpoint is not None and Path(checkpoint).exists():
+            if not Path(checkpoint).exists():
+                warnings.warn(f"Checkpoint {checkpoint} does not exist.")
+            else:
+                self._load(checkpoint, mode="training")
 
         self.gen.train()
         self.crit.train()


### PR DESCRIPTION
Hello,

Currently, if using Causal GAN, the training fails during initialization because of [src/factory.py#230](https://github.com/Emad-COMBINE-lab/GRouNdGAN/blob/2df087f9144081c46eb6ce0a1daadd273adcc50a/src/factory.py#L230). The cc.train() method expects the specified checkpoint to exist, but since the training is only starting, no checkpoint exists and an exception is raised. The checkpoint value should only be used when the Causal GAN is being initialized after training the causal controller.

This PR fixes this problem by only issuing a warning if specified checkpoint is not found.

Alternatively, I think removing lines 230 and 231 would also fix the problem, but I have not tested that.